### PR TITLE
CWD-1082: Component: Search: Remove placeholder text

### DIFF
--- a/package/lbcamden/components/search/template.njk
+++ b/package/lbcamden/components/search/template.njk
@@ -9,7 +9,7 @@
   </label>
   <input type="text" name="search"
          class="lbcamden-search__input"
-         id="lbcamden-search__box" placeholder="{{ params.placeholderText | default('Search') }}"/>
+         id="lbcamden-search__box" placeholder="{{ params.placeholderText | default('') }}"/>
   <button type="submit" class="lbcamden-search__btn"
           id="lbcamden-search__btn">{{ params.labelText | default('Search Camden.gov.uk') }}</button>
 </form>

--- a/src/lbcamden/components/search/template.njk
+++ b/src/lbcamden/components/search/template.njk
@@ -9,7 +9,7 @@
   </label>
   <input type="text" name="search"
          class="lbcamden-search__input"
-         id="lbcamden-search__box" placeholder="{{ params.placeholderText | default('Search') }}"/>
+         id="lbcamden-search__box" {% if params.placeholderText %}placeholder="{{ params.placeholderText }}{% endif %}" />
   <button type="submit" class="lbcamden-search__btn"
           id="lbcamden-search__btn">{{ params.labelText | default('Search Camden.gov.uk') }}</button>
 </form>

--- a/src/lbcamden/components/search/template.test.js
+++ b/src/lbcamden/components/search/template.test.js
@@ -32,12 +32,13 @@ describe('search', () => {
       expect($component.attr('name')).toEqual('search')
     })
 
-    it('input renders with placeholder="Search" by default', () => {
-      const $ = render('search', examples.default)
+    // AW: Removing as we no longer display placeholder by default
+    // it('input renders with placeholder="Search" by default', () => {
+    //   const $ = render('search', examples.default)
 
-      const $component = $('.lbcamden-search__input')
-      expect($component.attr('placeholder')).toEqual('Search')
-    })
+    //   const $component = $('.lbcamden-search__input')
+    //   expect($component.attr('placeholder')).toEqual('Search')
+    // })
 
     it('renders with a form', () => {
       const $ = render('search', examples.default)

--- a/src/lbcamden/components/search/template.test.js
+++ b/src/lbcamden/components/search/template.test.js
@@ -32,14 +32,6 @@ describe('search', () => {
       expect($component.attr('name')).toEqual('search')
     })
 
-    // AW: Removing as we no longer display placeholder by default
-    // it('input renders with placeholder="Search" by default', () => {
-    //   const $ = render('search', examples.default)
-
-    //   const $component = $('.lbcamden-search__input')
-    //   expect($component.attr('placeholder')).toEqual('Search')
-    // })
-
     it('renders with a form', () => {
       const $ = render('search', examples.default)
 


### PR DESCRIPTION
Change Bespoke Search component to make placeholder attribute optional and not set by default. Update tests to remove placeholder default test. Still able to set placeholder via param, but discouraged.