### PR TITLE
fix misalignment of header nav items on 1x pixel density screens

### DIFF
--- a/src/lbcamden/components/header/includes/_navigation-items.scss
+++ b/src/lbcamden/components/header/includes/_navigation-items.scss
@@ -196,6 +196,8 @@
       @include govuk-responsive-padding(3, "right");
       border-left: 1px solid lbcamden-colour("light-grey-2");
     }
+
+    line-height: normal;
   }
 }
 


### PR DESCRIPTION
This wasn't visible on screens at 2x pixel density and up, but a global line-height on list items (seemingly inherited from GOV.UK) was causing neader nav items with chevrons (which override line-height) to be slightly larger than those without (which don't)

![image](https://github.com/LBCamden/lbcamden-frontend/assets/361391/d73c716f-bdcd-4531-910a-6211baf3b898)

This overrides line-height on all header nav items, resolving the misalignment.