### PR TITLE
CWD-1113: Amend "Sign In / Register" nav item to be bold

### DIFF
--- a/src/lbcamden/components/header/includes/_navigation-items.scss
+++ b/src/lbcamden/components/header/includes/_navigation-items.scss
@@ -116,10 +116,6 @@
       color: lbcamden-colour("white");
     }
   }
-
-  &--sign-in {
-    @include govuk-typography-weight-regular;
-  }
 }
 
 &__navigation-item-link,


### PR DESCRIPTION
This doesn't actually change the developer docs itself - the change is made to the `lbcamden-header__navigation-item-link--sign-in` class. No markup change is needed to apply the change - it will be applied via a library update.