### PR TITLE
resolve promo gallery spacing issue

### DIFF
--- a/src/lbcamden/components/promo-gallery/index.scss
+++ b/src/lbcamden/components/promo-gallery/index.scss
@@ -1,9 +1,16 @@
 .lbcamden-promo-gallery--panel {
-  margin: 0 govuk-spacing(-4);
-  padding: govuk-spacing(4);
+  margin: 0 #{-$govuk-gutter-half};
+  padding: $govuk-gutter-half;
   padding-top: govuk-spacing(6);
-  padding-bottom: govuk-spacing(8);
+  padding-bottom: govuk-spacing(6);
   background-color: govuk-colour("white");
+
+  @include govuk-media-query($from: "desktop") {
+    margin: 0 govuk-spacing(-4);
+    padding: govuk-spacing(4);
+    padding-top: govuk-spacing(6);
+    padding-bottom: govuk-spacing(8);
+  }
 
   .lbcamden-promo-gallery--panel__all {
     @include govuk-responsive-margin(5, "top");


### PR DESCRIPTION
tiny tiny change to:

- prevent the promo gallery from overflowing the page horizontally when used inside a width-container on mobile
- tighten up spacing to match design spec on mobile