### PR TITLE
Families bug cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lbcamden-frontend",
-  "version": "0.2.7",
+  "version": "0.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lbcamden-frontend",
-      "version": "0.2.7",
+      "version": "0.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/lbcamden/components/emergency-banner/_index.scss
+++ b/src/lbcamden/components/emergency-banner/_index.scss
@@ -8,6 +8,10 @@
   color: govuk-colour("white");
   background-color: govuk-colour("mid-grey");
 
+  p {
+    color: inherit;
+  }
+
   &__heading {
     @include govuk-font(24, $weight: "bold");
     margin: 0;

--- a/src/lbcamden/components/emergency-banner/emergency-banner.yaml
+++ b/src/lbcamden/components/emergency-banner/emergency-banner.yaml
@@ -57,7 +57,7 @@ examples:
     data:
       campaignClass: notable-death
       heading:  His Royal Highness Henry VIII
-      shortDescription:  1491–1547
+      shortDescription: <p> 1491–1547</p>
       link: https://www.gov.uk/
       linkText: Override Link Text
   - name: notable death homepage
@@ -66,7 +66,7 @@ examples:
       homepage: true
       campaignClass: notable-death
       heading:  His Royal Highness Henry VIII
-      shortDescription:  1491–1547
+      shortDescription: <p> 1491–1547</p>
       link: https://www.gov.uk/
       linkText: Override Link Text
   - name: national emergency-banner
@@ -74,7 +74,7 @@ examples:
     data:
       campaignClass: national-emergency-banner
       heading:   National emergency-banner
-      shortDescription: This is a level 1 incident 
+      shortDescription: <p>This is a level 1 incident </p>
       link: https://www.gov.uk/
       linkText: Override Link Text
   - name: local emergency-banner
@@ -82,7 +82,7 @@ examples:
     data:
       campaignClass: local-emergency-banner
       heading:  Local emergency-banner
-      shortDescription:  This is a level 2 incident 
+      shortDescription: <p> This is a level 2 incident </p>
       link: https://www.gov.uk/
       linkText: Override Link Text
   - name: classes

--- a/src/lbcamden/components/emergency-banner/template.njk
+++ b/src/lbcamden/components/emergency-banner/template.njk
@@ -6,7 +6,7 @@
 
         {% if params.shortDescription %}
         <p class="lbcamden-emergency-banner__description {{ params.descriptionClasses }}">
-          {{ params.shortDescription }}
+          {{ params.shortDescription | safe }}
         </p>
         {% endif %}
 

--- a/src/lbcamden/components/header/_index.scss
+++ b/src/lbcamden/components/header/_index.scss
@@ -1,9 +1,10 @@
 $lbcamden-header-height: 50px;
 $lbcamden-header-colour: lbcamden-colour("black");
+$lbcamden-header-bar-colour: lbcamden-colour("govuk-brand1-1-colour");
 
 .lbcamden-header {
   position: relative;
-  border-bottom: 10px solid lbcamden-colour("govuk-brand1-1-colour");
+  border-bottom: 10px solid $lbcamden-header-bar-colour;
   color: lbcamden-colour("white");
   background: $lbcamden-header-colour;
 

--- a/src/lbcamden/components/header/_index.scss
+++ b/src/lbcamden/components/header/_index.scss
@@ -3,10 +3,13 @@ $lbcamden-header-colour: lbcamden-colour("black");
 
 .lbcamden-header {
   position: relative;
-  min-height: $lbcamden-header-height;
   border-bottom: 10px solid lbcamden-colour("govuk-brand1-1-colour");
   color: lbcamden-colour("white");
   background: $lbcamden-header-colour;
+
+  &__bar {
+    min-height: $lbcamden-header-height;
+  }
 
   &__logo {
     @include govuk-responsive-margin(2, "top");

--- a/src/lbcamden/components/header/header.yaml
+++ b/src/lbcamden/components/header/header.yaml
@@ -236,14 +236,8 @@ examples:
   - name: with no navigation
     description: Header with no main navigation.
     data:
-      navigation: false
-      searchItems:
-        - href: '#1'
-          text: 'Popular search 1'
-        - href: '#2'
-          text: 'Popular search 2'
-        - href: '#3'
-          text: 'Popular search 3'
+      navigation: []
+      searchItems: []
 
   - name: with phasebanner
     description: Default but with a phasebanner
@@ -253,7 +247,7 @@ examples:
   - name: with no navigation or search
     description: Header with no main navigation or search function.
     data:
-      navigation: false
+      navigation: []
       search: false
 
   - name: with death of a notable person
@@ -322,7 +316,35 @@ examples:
 
         - href: '#3'
           text: 'Sign in / Register'
-          classes: 'lbcamden-header__navigation-item-link--sign-in'      
+          classes: 'lbcamden-header__navigation-item-link--sign-in'
+
+  - name: with death of a notable person and no navigation
+    description: Header with emergency-banner banner for death of a notable person
+    data:
+      emergencyBanner: |
+        <section role="banner" class="lbcamden-emergency-banner lbcamden-emergency-banner--notable-death lbcamden-emergency-banner--homepage ">
+          <div class="govuk-width-container">
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-two-thirds">
+                <h2 class="lbcamden-emergency-banner__heading ">His Royal Highness Henry VIII</h2>
+
+                
+                <p class="lbcamden-emergency-banner__description ">
+                  1491–1547
+                </p>
+                
+
+                
+                <a href="https://www.gov.uk/" class="lbcamden-emergency-banner__link">
+                  Override Link Text
+                </a>
+                
+              </div>
+            </div>
+          </div>
+        </section>
+      navigation: []
+      search: false  
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: classes

--- a/src/lbcamden/components/header/template.njk
+++ b/src/lbcamden/components/header/template.njk
@@ -5,7 +5,7 @@
   class="lbcamden-header {{ params.classes if params.classes }}{% if params.phaseBanner %} lbcamden-header--with-phase-banner{% endif %}"
   role="banner" data-module="lbcamden-header"
 {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-<div class="{{ params.containerClasses | default('govuk-width-container') }}">
+<div class="lbcamden-header__bar {{ params.containerClasses | default('govuk-width-container') }}">
   <div class="lbcamden-header__logo">
     <a href="{{ params.homepageUrl | default('/') }}" class="lbcamden-header__link">
       {{ LBCamdenLogo({


### PR DESCRIPTION
- Allow only the brand bar colour (not the whole site brand) to be overridden in scss
- Resolve issue where the emergency banner is misaligned and replaces the header nav in some situations
- Allow shortDescription property of emergency banner to contain html markup