### PR TITLE
DS-114: Amend FE components to move class based styling to a class on a container div

### DIFF
--- a/src/lbcamden/components/all.test.js
+++ b/src/lbcamden/components/all.test.js
@@ -30,6 +30,7 @@ describe('When nunjucks is configured with a different base path', () => {
 
 it('_all.scss renders to CSS without errors', () => {
   return renderSass({
+    data: '@import "../base"; @import "../elements/all";',
     file: `${configPaths.src}/components/_all.scss`
   })
 })

--- a/src/lbcamden/components/emergency-banner/_index.scss
+++ b/src/lbcamden/components/emergency-banner/_index.scss
@@ -8,38 +8,38 @@
   color: govuk-colour("white");
   background-color: govuk-colour("mid-grey");
 
-  p {
-    color: inherit;
-  }
-
-  &__heading {
-    @include govuk-font(24, $weight: "bold");
-    margin: 0;
-    color: govuk-colour("white");
-  }
-
-  &__description {
-    @include govuk-font(16);
-    margin-top: 0;
-    margin-bottom: govuk-spacing(4);
-    color: govuk-colour("white");
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  &__link {
-    @include govuk-font(16);
-    color: govuk-colour("white");
-
-    &:link,
-    &:visited {
+  &__content {
+    > h2 {
+      @include govuk-font(24, $weight: "bold");
+      margin: 0;
       color: govuk-colour("white");
     }
 
-    &:focus {
-      @include govuk-focused-text;
+    > p {
+      @include govuk-font(16);
+      color: govuk-colour("white");
+
+      &:first-of-type {
+        margin-top: 0;
+      }
+
+      &:last-of-type {
+        margin-bottom: govuk-spacing(4);
+      }
+    }
+
+    > a:last-child {
+      @include govuk-font(16);
+      color: govuk-colour("white");
+
+      &:link,
+      &:visited {
+        color: govuk-colour("white");
+      }
+
+      &:focus {
+        @include govuk-focused-text;
+      }
     }
   }
 
@@ -67,8 +67,8 @@
     z-index: 10;
     margin-top: 0;
 
-    .lbcamden-emergency-banner {
-      &__heading {
+    .lbcamden-emergency-banner__content {
+      > h2 {
         @include govuk-font(36, $weight: "bold");
 
         @include govuk-media-query($from: "tablet") {
@@ -76,8 +76,12 @@
         }
       }
 
-      &__description {
-        margin: govuk-spacing(4) 0;
+      > p:first-of-type {
+        margin-top: govuk-spacing(4);
+      }
+
+      > p:last-of-type {
+        margin-bottom: govuk-spacing(4);
       }
     }
   }

--- a/src/lbcamden/components/emergency-banner/template.njk
+++ b/src/lbcamden/components/emergency-banner/template.njk
@@ -1,19 +1,17 @@
 <section role="banner" class="lbcamden-emergency-banner lbcamden-emergency-banner--{{ params.campaignClass }} {% if params.homepage %}lbcamden-emergency-banner--homepage{% endif %} {{ params.classes }}">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h2 class="lbcamden-emergency-banner__heading {{ params.headingClasses }}">{{ params.heading }}</h2>
+      <div class="govuk-grid-column-two-thirds lbcamden-emergency-banner__content">
+        <h2 class="{{ params.headingClasses }}">{{ params.heading }}</h2>
 
         {% if params.shortDescription %}
-        <p class="lbcamden-emergency-banner__description {{ params.descriptionClasses }}">
           {{ params.shortDescription | safe }}
-        </p>
         {% endif %}
 
         {% if params.link %}
-        <a href="{{ params.link }}" class="lbcamden-emergency-banner__link">
-          {{ params.linkText }}
-        </a>
+          <a href="{{ params.link }}">
+            {{ params.linkText }}
+          </a>
         {% endif %}
       </div>
     </div>

--- a/src/lbcamden/components/engagement-banner/_index.scss
+++ b/src/lbcamden/components/engagement-banner/_index.scss
@@ -22,18 +22,6 @@
     }
   }
 
-  &__heading:not(.lbcamden-engagement-banner__heading--mobile) {
-    @include govuk-responsive-margin(2, "bottom");
-
-    @include govuk-media-query($until: "desktop") {
-      display: none;
-    }
-  }
-
-  &__description {
-    @include govuk-responsive-margin(2, "bottom");
-  }
-
   &__image {
     width: 100%;
     aspect-ratio: 3 / 2;
@@ -50,6 +38,22 @@
 
     @include govuk-media-query($from: "desktop") {
       @include govuk-responsive-padding(6);
+    }
+
+    > h2 {
+      @include govuk-responsive-margin(2, "bottom");
+
+      @include govuk-media-query($until: "desktop") {
+        display: none;
+      }
+    }
+
+    > p:last-of-type {
+      @include govuk-responsive-margin(2, "bottom");
+    }
+
+    > a:last-child {
+      @extend .lbcamden-link--action;
     }
   }
 

--- a/src/lbcamden/components/engagement-banner/engagement-banner.yaml
+++ b/src/lbcamden/components/engagement-banner/engagement-banner.yaml
@@ -76,7 +76,7 @@ examples:
               - src: /example-assets/images/1800x1200.jpg
                 width: 1800
       heading:  News
-      shortDescription: Find out what’s going on in our community with all the latest news stories, announcements, and events.
+      shortDescription: <p>Find out what’s going on in our community with all the latest news stories, announcements, and events.</p>
       link: '#'
       linkText: All news
   - name: classes

--- a/src/lbcamden/components/engagement-banner/template.njk
+++ b/src/lbcamden/components/engagement-banner/template.njk
@@ -1,7 +1,7 @@
 {% from "../image/macro.njk" import LBCamdenImage %}
 
 <section role="banner" class="lbcamden-engagement-banner {{ params.classes }}">
-  <h2 class="lbcamden-engagement-banner__heading lbcamden-engagement-banner__heading--mobile">{{ params.heading }}</h2>
+  <h2 class="lbcamden-engagement-banner__heading--mobile">{{ params.heading }}</h2>
   {{ LBCamdenImage({
     classes: "lbcamden-engagement-banner__image",
     sources: params.image.sources,
@@ -12,15 +12,11 @@
   }) }}
 
   <div class="lbcamden-engagement-banner__content">
-    <h2 class="lbcamden-engagement-banner__heading">{{ params.heading }}</h2>
-    <p class="lbcamden-engagement-banner__description">
-      {{ params.shortDescription }}
-    </p>
+    <h2>{{ params.heading }}</h2>
+    {{ params.shortDescription | safe }}
 
     <a href="{{ params.link }}">
-      <span class="lbcamden-link--action">
-        {{ params.linkText }}
-      </span>
+      {{ params.linkText }}
     </a>
   </div>
 </section>

--- a/src/lbcamden/components/service-banner/_index.scss
+++ b/src/lbcamden/components/service-banner/_index.scss
@@ -3,16 +3,21 @@
   border-bottom: 2px solid lbcamden-colour("white");
   background-color: lbcamden-colour("govuk-brand1-6-colour");
 
-  &__heading {
+  h2 {
     @include govuk-font(24, "bold");
     margin: 0;
     margin-bottom: govuk-spacing(1);
     padding: 0;
   }
 
-  &__description {
+  p {
     @include govuk-font(16);
     margin: 0;
+    margin-bottom: govuk-spacing(1);
     padding: 0;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 }

--- a/src/lbcamden/components/service-banner/service-banner.yaml
+++ b/src/lbcamden/components/service-banner/service-banner.yaml
@@ -19,7 +19,8 @@ examples:
     description: Standard application of the service-banner element.
     data:
       heading: Council Tax and benefit forms unavailable
-      shortDescription: Council Tax and housing benefit application forms are unavailable this evening between 6pm and 9pm. Try again after this time.
+      shortDescription: <p>Council Tax and housing benefit application forms are unavailable this evening between 6pm and 9pm. Try again after this time.</p>
+
   - name: classes
     hidden: true
     data:

--- a/src/lbcamden/components/service-banner/template.njk
+++ b/src/lbcamden/components/service-banner/template.njk
@@ -2,13 +2,9 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="lbcamden-service-banner__heading {{ params.headingClasses }}">{{ params.heading }}</h2>
+        <h2 class="{{ params.headingClasses }}">{{ params.heading }}</h2>
 
-        {% if params.shortDescription %}
-        <p class="lbcamden-service-banner__description {{ params.descriptionClasses }}">
-          {{ params.shortDescription }}
-        </p>
-        {% endif %}
+        {{ params.shortDescription | safe }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This only addresses the first part of the ticket (removing the need for rich text content to have classes set) for the following components:

- Service Banner
- Emergency Banner
- Engagement Banner

We may want to also address this for the following components, which don't provide a shortDescription on camden.gov.uk:

- Promo gallery
- Link list gallery

This is a breaking change to nunjucks macros for sites (like our current Wagtail setup) that don't currently provide an html shortDescription values to the affected components.

To be discussed: How to support both uses if needed.