### PR TITLE
use brand colour variable instead of directly referencing a colour

### DIFF
--- a/src/lbcamden/elements/_row.scss
+++ b/src/lbcamden/elements/_row.scss
@@ -9,7 +9,7 @@
 
   &--related {
     @include govuk-responsive-margin(7, "top");
-    border-top: 3px solid lbcamden-colour("govuk-brand1-2-colour");
+    border-top: 3px solid $govuk-brand-colour;
     background: lbcamden-colour("govuk-bg-bright1-colour");
   }
 


### PR DESCRIPTION
Changed to `$govuk-brand-colour` variable instead of directly referencing a colour.