### PR TITLE
Rewrite pagination control to bring in line with govuk behaviour

### DIFF
--- a/src/lbcamden/elements/_pagination.scss
+++ b/src/lbcamden/elements/_pagination.scss
@@ -1,7 +1,16 @@
 .govuk-pagination {
   .govuk-pagination__link {
     svg {
-      @extend .govuk-visually-hidden;
+      > * {
+        opacity: 0;
+      }
+
+      background-position: center;
+      background-size: 9px;
+
+      @include govuk-media-query($from: tablet) {
+        background-size: 12px;
+      }
     }
   }
 
@@ -18,49 +27,14 @@
   }
 
   &__prev {
-    .govuk-pagination__link {
-      @include govuk-responsive-padding(5, "left");
-
-      &:before {
-        content: "";
-        position: absolute;
-        left: 0;
-        @include lbcamden-chevron(lbcamden-colour("grey"), 180, 1, 3);
-      }
+    svg {
+      @include lbcamden-chevron(lbcamden-colour("grey"), 180, 1, 4);
     }
   }
 
   &__next {
-    .govuk-pagination__link {
-      @include govuk-responsive-padding(5, "right");
-
-      &:before {
-        content: "";
-        position: absolute;
-        right: 0;
-        @include lbcamden-chevron(lbcamden-colour("grey"), 0, 1, 3);
-      }
-    }
-  }
-
-  &--block {
-    .govuk-pagination__prev,
-    .govuk-pagination__next {
-      .govuk-pagination__link {
-        position: relative;
-
-        &:before {
-          top: 4px;
-          left: 0;
-        }
-      }
-    }
-
-    .govuk-pagination__next {
-      .govuk-pagination__link {
-        @include govuk-responsive-padding(5, "left");
-        @include govuk-responsive-padding(0, "right");
-      }
+    svg {
+      @include lbcamden-chevron(lbcamden-colour("grey"), 0, 1, 4);
     }
   }
 }


### PR DESCRIPTION
We had a fairly fragile set of overrides on the govuk-pagination component to apply our design system's chevron icon.

This seem to have broken the focus state at some point due to a govuk upgrade.

This replaces the overrides with a hopefully less fragile approach of overriding the chevron svg element using background-image instead of throwing additional elements in that mess with the layout.