### PR TITLE
FH770 - Demo of Card Gallery amends in a content page with example

### DIFF
--- a/app/views/full-page-examples/article_grid/index.njk
+++ b/app/views/full-page-examples/article_grid/index.njk
@@ -1,0 +1,441 @@
+---
+scenario: You want to change your name by deed poll
+notes:
+---
+{% extends "full-page-example.njk" %}
+{% set mainClasses = 'govuk-width-container' %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set pageTitle = "Change you name by deed poll" %}
+{% block pageTitle %}{{ pageTitle }} - CAMDEN.GOV.UK{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "#/"
+      },
+      {
+        text: "Births, deaths, marriages and citizenship",
+        href: "#/"
+      }
+    ]
+  }) }}
+{% endblock %}
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h1>Change your name by deed poll</h1>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop lbcamden-prose">
+
+      <h2>What is a deed poll?</h2>
+
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          A deed poll is a legal document that binds an individual to a particular course of action. The most common
+        use
+        of a deed poll is to change a name.
+        </strong>
+      </div>
+
+<div class="lbcamden-card-gallery ">
+    <ul class="lbcamden-card-grid" style="list-style-type:none; padding-left:0; grid-template-columns: 1fr 1fr;">
+            <li class="lbcamden-card-grid--link-wrapper">
+              
+  
+{% from "card/macro.njk" import LBCamdenCard %}
+
+{{ LBCamdenCard({
+  "content": {
+    "text": "Get help and support for you and your child, apply for a new school place, find term dates and school travel."
+  },
+  "type": "naked",
+  "image": {
+    "src": "/example-assets/images/1800x1200.jpg",
+    "alt": "Image of Camden market"
+  }
+}) }}
+
+            </li>
+            <li class="lbcamden-card-grid--link-wrapper">
+              
+{{ LBCamdenCard({
+  "content": {
+    "text": "Get help and support for you and your child, apply for a new school place, find term dates and school travel."
+  },
+  "type": "naked",
+  "image": {
+    "src": "/example-assets/images/1800x1200.jpg",
+    "alt": "Image of Camden market"
+  }
+}) }}
+
+            </li>
+            <li class="lbcamden-card-grid--link-wrapper">
+              
+{{ LBCamdenCard({
+  "content": {
+    "text": "Get help and support for you and your child, apply for a new school place, find term dates and school travel."
+  },
+  "type": "naked",
+  "image": {
+    "src": "/example-assets/images/1800x1200.jpg",
+    "alt": "Image of Camden market"
+  }
+}) }}
+
+            </li>
+            <li class="lbcamden-card-grid--link-wrapper">
+              
+{{ LBCamdenCard({
+  "content": {
+    "text": "Get help and support for you and your child, apply for a new school place, find term dates and school travel."
+  },
+  "type": "naked",
+  "image": {
+    "src": "/example-assets/images/1800x1200.jpg",
+    "alt": "Image of Camden market"
+  }
+}) }}
+
+            </li>
+<li class="lbcamden-card-grid--link-wrapper">
+              
+{{ LBCamdenCard({
+  "content": {
+    "text": "Get help and support for you and your child, apply for a new school place, find term dates and school travel."
+  },
+  "type": "naked",
+  "image": {
+    "src": "/example-assets/images/1800x1200.jpg",
+    "alt": "Image of Camden market"
+  }
+}) }}
+
+            </li>
+    </ul>
+</div>
+
+
+
+
+      <p>A deed poll is a legal document that binds an individual to a particular course of action. The most common
+        use
+        of a deed poll is to change a name. A deed poll commits you to the following actions:</p>
+
+      <ul>
+        <li>to renounce and abandon the use of your former name(s)</li>
+        <li>to use your new name(s) at all times</li>
+        <li>requires everybody to address you only by your new name(s)</li>
+      </ul>
+
+      <h3>Adults</h3>
+
+      <p>Anyone over the age of 16 can change their name by deed poll. If you are aged over 16 years but not yet 18
+        years old, the process is the same as it is for an adult. You do not need the consent of whoever has parental
+        responsibility for you. Please <a href="https://www.camden.gov.uk/">book an appointment</a> and come with relevant ID and a witness.</p>
+
+      <p><a href="https://www.camden.gov.uk/" class="lbcamden-button">Link button</a></p>
+
+      <h3>Children</h3>
+
+      <p>A person who has parental responsibility must apply for the name change on behalf of the child. Camden only
+        completes a deed poll service where all parents mentioned on a birth certificate (or organisations) that have
+        parental rights and responsibilities over the child are able to attend and agree to the name change.&nbsp;Please
+        book an appointment and come with relevant ID and a witness.</p>
+
+      <p><a href="https://www.camden.gov.uk/" role="button" draggable="false" class="lbcamden-button lbcamden-button--start" data-module="lbcamden-button">
+        Start now link button
+        <svg class="lbcamden-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" aria-hidden="true" focusable="false">
+          <path d="M4.48116 7L0.409421 11.3565H0.409258C0.05163 11.7527 -0.0842445 12.3214 0.0519564 12.8525C0.188157 13.3837 0.576033 13.7987 1.07245 13.9444C1.56887 14.0901 2.10045 13.9448 2.47074 13.5621L7.57322 8.10283C7.84641 7.81019 8 7.41361 8 7C8 6.58638 7.8464 6.1898 7.57322 5.89718L2.47074 0.437877C2.10042 0.0552407 1.56887 -0.0901382 1.07245 0.0555872C0.576033 0.201313 0.188161 0.616313 0.0519564 1.14745C-0.0842487 1.67858 0.0516291 2.24733 0.409258 2.64352L4.48116 7Z" fill="currentColor"/>
+        </svg></a></p>
+
+      <h2>How much does a deed poll cost?</h2>
+
+      <ul>
+        <li>Monday to&nbsp;Friday 9am-3.30pm: £62</li>
+        <li>Monday to Friday from 4.45pm: £75</li>
+        <li>Saturday: £75</li>
+        <li>Additional copy of document: £12.60&nbsp;</li>
+      </ul>
+
+      <p>You cannot obtain further copies afterwards, so make sure you order as many as you need at the time you sign
+        your deed poll</p>
+
+      <p>
+        <a href="https://www.camden.gov.uk/" class="lbcamden-link--action">
+          Action link
+        </a>
+      </p>
+
+      <h2>When&nbsp;would I need to use a deed poll?</h2>
+
+      <p>For most purposes a deed poll will be accepted to change documents, but there are some important exceptions.
+        Birth and marriage certificates cannot be changed. However, your deed poll together with your birth
+        certificate
+        will be sufficient for the passport office to issue you with a passport in the new name.&nbsp;<br> If the
+        purpose of your deed poll is to alter a particular document it is important to check first with the issuer
+        that
+        a change will be allowed.</p>
+
+      <div class="lbcamden-table--scroll-container">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Band</th>
+              <th scope="col">Amount of Council Tax for Camden (£)</th>
+              <th scope="col">Amount of Council Tax for GLA (£)</th>
+              <th scope="col">Total Council Tax 2023/2024 (£)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">A</th>
+              <td>£977.35</td>
+              <td>£289.43</td>
+              <td>£1,266.78</td>
+            </tr>
+            <tr>
+              <th scope="row">B</th>
+              <td>£1,140.24</td>
+              <td>£337.66</td>
+              <td>£1,477.90</td>
+            </tr>
+            <tr>
+              <th scope="row">C</th>
+              <td>£1,303.13</td>
+              <td>£385.90</td>
+              <td>£1,689.03</td>
+            </tr>
+            <tr>
+              <th scope="row">D</th>
+              <td>£1,466.02</td>
+              <td>£434.14</td>
+              <td>£1,900.16</td>
+            </tr>
+            <tr>
+              <th scope="row">E</th>
+              <td>£1,791.80</td>
+              <td>£530.62</td>
+              <td>£2,322.42</td>
+            </tr>
+            <tr>
+              <th scope="row">F</th>
+              <td>£2,177.58</td>
+              <td>£627.09</td>
+              <td>£2,744.67</td>
+            </tr>
+            <tr>
+              <th scope="row">G</th>
+              <td>£2,443.36</td>
+              <td>£723.57</td>
+              <td>£3,166.93</td>
+            </tr>
+            <tr>
+              <th scope="row">H</th>
+              <td>£2,932.04</td>
+              <td>£868.28</td>
+              <td>£3,800.32</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2>What about my name can I change?</h2>
+
+      <h3>You can:</h3>
+
+      <ul>
+        <li>change your entire name</li>
+        <li>add or remove surnames, forenames and middle names</li>
+        <li>rearrange your names</li>
+        <li>alter spellings of names</li>
+      </ul>
+
+      <div class="govuk-inset-text">
+        It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
+      </div>
+
+      <p>Although the possibilities are almost limitless there are some basic conditions that your new name will have
+        to
+        meet. On the whole these restrictions are to ensure that you will not have problems when changing documents
+        such
+        as your passport.</p>
+      <p>We will not accept names in the following circumstances:</p>
+
+      <ul>
+        <li>If the name is offensive.</li>
+        <li>If the name is impossible to pronounce.</li>
+        <li>If the name contains numbers, symbols or punctuation marks. &nbsp;Apostrophes are accepted in the context
+          of
+          a name (such as O’Neill) as are hyphens to link two names together (such as Smith-Johnson).
+        </li>
+        <li>Recognized accents are accepted, but be aware that the use of accents in the UK is not widespread and
+          confusion can arise if they are inconsistently used.
+        </li>
+        <li>The name must contain at least one forename and at least one surname.</li>
+        <li>You may not add a title such as Lord or Duke unless you can provide documentary proof of your entitlement
+          to
+          usage. &nbsp;Purchased titles are not accepted.
+        </li>
+        <li>Academic titles such as Professor will only be included if documentary proof is provided. &nbsp;Purchased
+          qualifications will not be accepted.
+        </li>
+        <li>Amusing names can be accepted, but you should consider carefully if this will have consequences in your
+          personal or professional life.
+        </li>
+      </ul>
+
+      <p>The conditions listed above are guidelines and the acceptance or refusal of a name is at the discretion of
+        the
+        Registering Officer.</p>
+
+      <h2>Do I really need to change my name by deed poll?</h2>
+
+      <p>In theory, you could change your name simply by starting to use a new one. This is called a name change by
+        usage.&nbsp;The main problem with this method is that many organisations will only change your name if you
+        produce substantial documentary evidence of the name change.</p>
+      <p>There are times when a deed poll is not needed to change a name:</p>
+
+      <ul>
+        <li>After marriage or civil partnership. A woman who wants to change her surname to that of her husband uses
+          her
+          marriage certificate. A civil partner uses their civil partnership certificate to change their surname
+        </li>
+        <li>After divorce. A woman can revert to her maiden surname by using her decree absolute</li>
+        <li>After being widowed. A woman reverting to her maiden name after being widowed can use her late husband’s
+          death certificate together with her marriage certificate to change her name.&nbsp;
+        </li>
+      </ul>
+
+      <h2>How do I apply for a deed poll?</h2>
+
+      <p>You will need to book an appointment. Once you’ve booked your appointment your completed online application
+        form will need to be printed and signed when you attend.</p>
+
+      <ul class="lbcamden-list--dash">
+        <li><a href="https://www.camden.gov.uk/">Greater London Authority Information 2023/24 (PDF, 78KB)</a></li>
+        <li><a href="https://www.camden.gov.uk/">More information about Greater London Authority (GLA) services</a></li>
+        <li><a href="https://www.camden.gov.uk/">Notice of Lee Valley Regional Park Authority levy 2023/24 (PDF, 267KB)</a></li>
+        <li><a href="https://www.camden.gov.uk/">Environment Agency levy 2023/24 (PDF, 46KB)</a></li>
+        <li><a href="https://www.camden.gov.uk/">LPFA levy for 2023/24 (PDF, 36KB)</a></li>
+      </ul>
+
+      <p>Ensure you bring a suitable witness and the appropriate evidence of your identity to your
+        appointment.&nbsp;</p>
+
+      <ol class="govuk-list govuk-list--number">
+        <li>Delivery address</li>
+        <li>Payment</li>
+        <li>Confirmation</li>
+      </ol>
+
+      <p>In theory, you could change your name simply by starting to use a new one. This is called a name change by
+        usage.&nbsp;The main problem with this method is that many organisations will only change your name if you
+        produce substantial documentary evidence of the name change.</p>
+
+      <p><a class="lbcamden-button"
+            href="https://www.camden.gov.uk/">Book
+          an appointment</a></p>
+    </div>
+    <div class="govuk-grid-column-one-third-from-desktop">
+      <aside class="lbcamden-card lbcamden-card--alt-1">
+        <h2>Related content</h2>
+        <div class="lbcamden-card__content">
+          <p>Contrary to popular belief, Lorem Ipsum is not simply random text</p>
+          <ul class="lbcamden-list lbcamden-list--dash">
+            <li><a href="https://www.camden.gov.uk/">Example</a></li>
+            <li><a href="https://www.camden.gov.uk/">Example</a></li>
+            <li><a href="https://www.camden.gov.uk/">Example</a></li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {{ LBCamdenFooter({
+    "navigation": [
+        {
+          "href": "#1",
+          "text": "Home"
+        },
+        {
+          "href": "#2",
+          "text": "Site map"
+        },
+        {
+          "href": "#3",
+          "text": "Contact Camden Council"
+        }
+    ],
+    "navigationSecondary": [
+        {
+          "href": "#4",
+          "text": "Subscribe to our e-newsletter",
+          "attributes": {
+            "data-highlighted": true
+          }
+        }
+    ],
+    "navigationUtility": [
+
+        {
+          "href": "#1",
+          "text": "Accessibility statement"
+        },
+        {
+          "href": "#2",
+          "text": "Freedom of information disclaimer"
+        },
+        {
+          "href": "#3",
+          "text": "Privacy statement & cookies"
+        },
+        {
+          "href": "#4",
+          "text": "Modern slavery statement"
+        }
+    ],
+
+    "navigationSocial": [
+        {
+          "href": "#1",
+          "text": "Navigation item 1",
+          "attributes": {
+            "data-icon": "facebook"
+          }
+        },
+        {
+          "href": "#2",
+          "text": "Navigation item 2",
+          "attributes": {
+            "data-icon": "youtube"
+          }
+        },
+        {
+          "href": "#3",
+          "text": "Navigation item 3",
+          "attributes": {
+            "data-icon": "twitter"
+          }
+        },
+        {
+          "href": "#4",
+          "text": "Navigation item 4",
+          "attributes": {
+            "data-icon": "linkedin"
+          }
+      }
+    ]
+  }) }}
+{% endblock %}


### PR DESCRIPTION
This is an example of a modified Card Gallery component in an Article Page context.

I think we could amends the Card Gallery CSS to say if component is in a `govuk-grid-column-two-thirds-from-desktop` container with `lbcamden-prose` class as well, we apply the inline styles on line 50 of the article_grid/index page.

We also need to add in a media query for small breakpoints that set `grid-template-columns` to `1fr` only.